### PR TITLE
Enable incremental builds and expand TS path aliases

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",  // Verweist auf die Haupt-tsconfig, um alle allgemeinen Optionen zu übernehmen
   "compilerOptions": {
+    "incremental": true,  // Aktiviert inkrementelle Builds
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",  // Speicherort für TypeScript-Cache-Dateien (wird bei der nächsten Kompilierung genutzt)
     "strict": true,
     "noFallthroughCasesInSwitch": true,  // Sorgt dafür, dass es keine unbeabsichtigten Fallthroughs in Switch-Anweisungen gibt

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "esnext",  // Moderne JavaScript-Version verwenden
     "module": "esnext",  // Verwende ES-Module, um moderne JavaScript-Features zu nutzen
     "moduleResolution": "node",  // Stellen sicher, dass Node.js-Modulauflösung verwendet wird
+    "incremental": true,  // Aktiviert inkrementelle Builds für schnellere Kompilierung
     "strict": true,  // Aktiviert alle strengen TypeScript-Überprüfungen
     "noUnusedLocals": true,  // Überprüft, ob es unbenutzte Variablen gibt
     "noUnusedParameters": true,  // Überprüft, ob es unbenutzte Parameter gibt
@@ -12,7 +13,10 @@
     "outDir": "./dist",  // Ordner für den Build-Ausgabepfad
     "baseUrl": ".",  // Legt den Basis-Pfad fest (relativ zum Projekt)
     "paths": {
-      "@/*": ["src/*"]  // Erlaubt Aliase wie `@/components/Button.vue` für das Erstellen von Komponentenpfaden
+      "@/*": ["src/*"],  // Erlaubt Aliase wie `@/components/Button.vue` für das Erstellen von Komponentenpfaden
+      "@assets/*": ["src/assets/*"],  // Alias für Assets
+      "@router/*": ["src/router/*"],  // Alias für Router-Dateien
+      "@styles/*": ["src/styles/*"]  // Alias für globale Styles
     }
   },
   "include": [

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,6 +4,8 @@
     "target": "esnext",  // Für Node.js sollten wir auch esnext als Ziel verwenden
     "module": "commonjs",  // Verwende CommonJS-Module für Node.js
     "outDir": "./dist",  // Ausgabeordner für Build-Dateien
+    "incremental": true,  // Aktiviert inkrementelle Builds für schnellere Kompilierung
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",  // Speicherort für TypeScript-Cache-Dateien
     "esModuleInterop": true  // Kompatibilität mit CommonJS-Modulen
   },
   "include": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,6 +33,9 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         '@': '/src',
+        '@assets': '/src/assets',
+        '@router': '/src/router',
+        '@styles': '/src/styles',
       },
     },
   }


### PR DESCRIPTION
## Summary
- enable incremental TypeScript compilation across project configs
- add path aliases for assets, router, and styles in tsconfig and Vite