### PR TITLE
feat: configure vite build and vitest setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + Vue + TS</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -8,22 +8,30 @@
     "dev:test": "vite --mode test",
     "build": "vite build",
     "build:test": "vite build --mode test",
-    "serve": "vite preview",
+    "preview": "vite preview",
     "lint": "eslint --ext .ts,.tsx,.vue src",
     "format": "prettier --write .",
-    "test": "jest"
+    "test": "vitest run",
+    "test:ui": "vitest",
+    "coverage": "vitest run --coverage",
+    "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
     "vue": "^3.5.18"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/vue": "^8.2.1",
     "@vitejs/plugin-vue": "^6.0.1",
+    "@vitest/coverage-v8": "^2.1.4",
+    "@vue/test-utils": "^2.4.5",
     "@vue/tsconfig": "^0.7.0",
     "eslint": "^8.57.0",
-    "jest": "^29.7.0",
+    "jsdom": "^25.0.1",
     "prettier": "^3.3.3",
     "typescript": "^5.9.2",
     "vite": "^7.1.2",
+    "vitest": "^2.1.4",
     "vue-tsc": "^3.0.5"
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@ import HelloWorld from './components/HelloWorld.vue'
 <template>
   <div>
     <a href="https://vite.dev" target="_blank">
-      <img src="/vite.svg" class="logo" alt="Vite logo" />
+      <img src="@/assets/vite.svg" class="logo" alt="Vite logo" />
     </a>
     <a href="https://vuejs.org/" target="_blank">
       <img src="./assets/vue.svg" class="logo vue" alt="Vue logo" />

--- a/src/__tests__/App.test.ts
+++ b/src/__tests__/App.test.ts
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/vue'
+import { describe, it, expect } from 'vitest'
+import App from '@/App.vue'
+
+describe('App', () => {
+  it('renders without crashing', () => {
+    render(App)
+    expect(true).toBe(true)
+  })
+})

--- a/src/__tests__/smoke.test.ts
+++ b/src/__tests__/smoke.test.ts
@@ -1,0 +1,5 @@
+import { describe, it, expect } from 'vitest'
+
+describe('smoke', () => {
+  it('works', () => expect(1 + 1).toBe(2))
+})

--- a/src/assets/vite.svg
+++ b/src/assets/vite.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+defineProps<{ msg: string }>()
+</script>
+
+<template>
+  <h1>{{ msg }}</h1>
+</template>

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,6 @@
+#app {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+  text-align: center;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import { fileURLToPath, URL } from 'node:url'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -32,11 +33,16 @@ export default defineConfig(({ mode }) => {
     },
     resolve: {
       alias: {
-        '@': '/src',
-        '@assets': '/src/assets',
-        '@router': '/src/router',
-        '@styles': '/src/styles',
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+        '@assets': fileURLToPath(new URL('./src/assets', import.meta.url)),
+        '@router': fileURLToPath(new URL('./src/router', import.meta.url)),
+        '@styles': fileURLToPath(new URL('./src/styles', import.meta.url)),
       },
+    },
+    test: {
+      environment: 'jsdom',
+      setupFiles: ['./vitest.setup.ts'],
+      coverage: { provider: 'v8' },
     },
   }
 })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,2 @@
+import '@testing-library/jest-dom'
+// Optionale globale Mocks/Stubs können hier ergänzt werden.


### PR DESCRIPTION
## Summary
- add Vite app scaffolding with index.html and example components
- configure Vitest with jsdom and setup file
- provide sample tests and scripts for build, test, and type checking

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run build`
- `npm run typecheck` *(fails: cannot find module '@testing-library/vue')*

------
https://chatgpt.com/codex/tasks/task_e_68bcc43d4ae08322a9460e7ce1b768dd