### PR TITLE
fix: update eslint config for vue plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,8 +2,7 @@
   "root": true,
   "env": {
     "browser": true,
-    "es2021": true,
-    "vue/setup-compiler-macros": true
+    "es2021": true
   },
   "parser": "vue-eslint-parser",
   "parserOptions": {
@@ -15,7 +14,7 @@
   "plugins": ["vue", "@typescript-eslint"],
   "extends": [
     "eslint:recommended",
-    "plugin:vue/vue3-recommended",
+    "plugin:vue/recommended",
     "plugin:@typescript-eslint/recommended"
   ],
   "rules": {


### PR DESCRIPTION
## Summary
- use `plugin:vue/recommended` instead of deprecated config
- drop unsupported `vue/setup-compiler-macros` env entry

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`